### PR TITLE
Frontend static build files now expected in the backend directory

### DIFF
--- a/govapp/settings.py
+++ b/govapp/settings.py
@@ -118,7 +118,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/3.2/howto/static-files/
 STATIC_URL = "/static/"
 STATICFILES_DIRS = [
-    BASE_DIR / "govapp/frontend/static"  # Look for static files in the frontend
+    BASE_DIR / "govapp/static"  # Look for static files in the frontend
 ]
 
 # Default primary key field type


### PR DESCRIPTION
## Summary
* Previously the Django backend expected the built frontend files to be in `govapp/frontend/static`
* Frontend actually builds into the directory above (`govapp/static`)
* Hopefully this fixes the build issues