### PR TITLE
Initial Create/Update Notifications for Catalogue Entries

### DIFF
--- a/govapp/apps/accounts/utils.py
+++ b/govapp/apps/accounts/utils.py
@@ -1,0 +1,38 @@
+"""Kaartdijin Boodja Accounts Django Application Utility Functions."""
+
+
+# Third-Party
+from django import conf
+from django.contrib import auth
+from django.contrib.auth import models
+
+# Typing
+from typing import Iterable
+
+
+# Shortcuts
+UserModel = auth.get_user_model()
+
+
+def all_administrators() -> Iterable[models.User]:
+    """Retrieves all of the administrator users.
+
+    Yields:
+        models.User: Users in the administrator group.
+    """
+    # Retrieve and Yield
+    yield from UserModel.objects.filter(
+        groups__id=conf.settings.GROUP_ADMINISTRATOR_ID
+    )
+
+
+def all_catalogue_editors() -> Iterable[models.User]:
+    """Retrieves all of the administrator users.
+
+    Yields:
+        models.User: Users in the administrator group.
+    """
+    # Retrieve and Yield
+    yield from UserModel.objects.filter(
+        groups__id=conf.settings.GROUP_CATALOGUE_EDITOR_ID
+    )

--- a/govapp/apps/catalogue/absorber.py
+++ b/govapp/apps/catalogue/absorber.py
@@ -12,10 +12,12 @@ from django.db import transaction
 import reversion
 
 # Local
+from . import emails
 from . import models
 from . import readers
 from . import storage
 from . import utils
+from ..accounts import utils as accounts_utils
 
 # Typing
 from typing import Optional
@@ -192,6 +194,11 @@ class Absorber:
                     catalogue_entry=catalogue_entry,
                 )
 
+        # Send Emails!
+        emails.CatalogueEntryCreatedEmail().send_to_users(
+            *accounts_utils.all_administrators(),  # Send to all administrators
+        )
+
     @transaction.atomic()
     @reversion.create_revision()  # type: ignore[misc]
     def update_catalogue_entry(
@@ -229,3 +236,18 @@ class Absorber:
 
         # Attempt to "Activate" this Layer Submission
         layer_submission.activate()
+
+        # Check Layer Submission
+        if layer_submission.is_declined():
+            # Send Update Failure Email
+            emails.CatalogueEntryUpdateFailEmail().send_to_users(
+                *accounts_utils.all_administrators(),  # Send to all administrators
+                catalogue_entry.assigned_to,  # Send to assigned user if applicable
+            )
+
+        else:
+            # Send Update Success Email
+            emails.CatalogueEntryUpdateSuccessEmail().send_to_users(
+                *accounts_utils.all_administrators(),  # Send to all administrators
+                catalogue_entry.assigned_to,  # Send to assigned user if applicable
+            )

--- a/govapp/apps/catalogue/absorber.py
+++ b/govapp/apps/catalogue/absorber.py
@@ -227,5 +227,5 @@ class Absorber:
                 catalogue_entry=catalogue_entry,
             )
 
-        # Update Catalogue Entry with Layer Submission
-        layer_submission.update_catalogue_entry()
+        # Attempt to "Activate" this Layer Submission
+        layer_submission.activate()

--- a/govapp/apps/catalogue/emails.py
+++ b/govapp/apps/catalogue/emails.py
@@ -1,0 +1,27 @@
+
+"""Kaartdijin Boodja Catalogue Django Application Emails."""
+
+
+# Local
+from ..emails import emails
+
+
+class CatalogueEntryCreatedEmail(emails.TemplateEmailBase):
+    """Catalogue Entry Created Email Abstraction."""
+    subject = "A new Catalogue Entry was created"
+    html_template = "catalogue_entry_created_email.html"
+    txt_template = "catalogue_entry_created_email.txt"
+
+
+class CatalogueEntryUpdateSuccessEmail(emails.TemplateEmailBase):
+    """Catalogue Entry Update Success Email Abstraction."""
+    subject = "A Catalogue Entry update was successful"
+    html_template = "catalogue_entry_update_success_email.html"
+    txt_template = "catalogue_entry_update_success_email.txt"
+
+
+class CatalogueEntryUpdateFailEmail(emails.TemplateEmailBase):
+    """Catalogue Entry Update Fail Email Abstraction."""
+    subject = "A Catalogue Entry update failed"
+    html_template = "catalogue_entry_update_fail_email.html"
+    txt_template = "catalogue_entry_update_fail_email.txt"

--- a/govapp/apps/catalogue/models/catalogue_entries.py
+++ b/govapp/apps/catalogue/models/catalogue_entries.py
@@ -132,6 +132,11 @@ class CatalogueEntry(models.Model):
         """Locks the Catalogue Entry."""
         # Check Catalogue Entry
         if self.is_unlocked():
+            # Check if Catalogue Entry is new
+            if self.is_new():
+                # Lock the currently active layer
+                self.active_layer.accept()
+
             # Calculate the attributes hash
             attributes_hash = utils.attributes_hash(self.attributes.all())
 

--- a/govapp/apps/catalogue/models/catalogue_entries.py
+++ b/govapp/apps/catalogue/models/catalogue_entries.py
@@ -123,7 +123,7 @@ class CatalogueEntry(models.Model):
         """Determines whether the Catalogue Entry is a new draft.
 
         Returns:
-            bool: Whether the Catalogue Entry is unlocked.
+            bool: Whether the Catalogue Entry is a new draft.
         """
         # Check and Return
         return self.status == CatalogueEntryStatus.NEW_DRAFT

--- a/govapp/apps/catalogue/models/layer_submissions.py
+++ b/govapp/apps/catalogue/models/layer_submissions.py
@@ -45,6 +45,15 @@ class LayerSubmission(models.Model):
         # Generate String and Return
         return f"{self.name}"
 
+    def is_declined(self) -> bool:
+        """Determines whether the Layer Submission is declined.
+
+        Returns:
+            bool: Whether the Layer Submission is declined.
+        """
+        # Check and Return
+        return self.status == LayerSubmissionStatus.DECLINED
+
     def accept(self) -> None:
         """Accepts the Layer Submission for locking of new Catalogue Entry."""
         # Set Status and Save

--- a/govapp/apps/catalogue/models/layer_submissions.py
+++ b/govapp/apps/catalogue/models/layer_submissions.py
@@ -45,7 +45,13 @@ class LayerSubmission(models.Model):
         # Generate String and Return
         return f"{self.name}"
 
-    def update_catalogue_entry(self) -> None:
+    def accept(self) -> None:
+        """Accepts the Layer Submission for locking of new Catalogue Entry."""
+        # Set Status and Save
+        self.status = LayerSubmissionStatus.ACCEPTED
+        self.save()
+
+    def activate(self) -> None:
         """Updates the Layer Submission's Catalogue Entry with this layer."""
         # Check the created date?
         # TODO

--- a/govapp/apps/catalogue/templates/catalogue_entry_created_email.html
+++ b/govapp/apps/catalogue/templates/catalogue_entry_created_email.html
@@ -1,0 +1,7 @@
+{% extends 'base_email.html' %}
+
+{% block content %}
+<p>
+    A new catalogue entry was created!
+</p>
+{% endblock %}

--- a/govapp/apps/catalogue/templates/catalogue_entry_created_email.txt
+++ b/govapp/apps/catalogue/templates/catalogue_entry_created_email.txt
@@ -1,0 +1,5 @@
+{% extends 'base_email.txt' %}
+
+{% block content %}
+A new catalogue entry was created!
+{% endblock %}

--- a/govapp/apps/catalogue/templates/catalogue_entry_update_fail_email.html
+++ b/govapp/apps/catalogue/templates/catalogue_entry_update_fail_email.html
@@ -1,0 +1,7 @@
+{% extends 'base_email.html' %}
+
+{% block content %}
+<p>
+    A catalogue entry update failed!
+</p>
+{% endblock %}

--- a/govapp/apps/catalogue/templates/catalogue_entry_update_fail_email.txt
+++ b/govapp/apps/catalogue/templates/catalogue_entry_update_fail_email.txt
@@ -1,0 +1,5 @@
+{% extends 'base_email.txt' %}
+
+{% block content %}
+A catalogue entry update failed!
+{% endblock %}

--- a/govapp/apps/catalogue/templates/catalogue_entry_update_success_email.html
+++ b/govapp/apps/catalogue/templates/catalogue_entry_update_success_email.html
@@ -1,0 +1,7 @@
+{% extends 'base_email.html' %}
+
+{% block content %}
+<p>
+    A catalogue entry update was successful!
+</p>
+{% endblock %}

--- a/govapp/apps/catalogue/templates/catalogue_entry_update_success_email.txt
+++ b/govapp/apps/catalogue/templates/catalogue_entry_update_success_email.txt
@@ -1,0 +1,5 @@
+{% extends 'base_email.txt' %}
+
+{% block content %}
+A catalogue entry update was successful!
+{% endblock %}


### PR DESCRIPTION
## Summary
* See ticket(s): `2020`, `2165`, `2166`, `2192`
* Adds new emails for Catalogue Entry creation, update (success) and update (failure)
* Adds functionality to send the above emails when appropriate
* Adds some utilities to the `accounts` app (to retrieve admins and catalogue editors)
* Adds logic to `ACCEPT` the Layer Submission upon initial Catalogue Entry locking