### PR TITLE
Add `assign` and `unassign` endpoints to Catalogue Entry

### DIFF
--- a/govapp/apps/accounts/permissions.py
+++ b/govapp/apps/accounts/permissions.py
@@ -1,0 +1,53 @@
+"""Kaartdijin Boodja Accounts Django Application Permissions."""
+
+
+# Third-Party
+from rest_framework import permissions
+from rest_framework import request
+from rest_framework import viewsets
+
+# Local
+from . import utils
+
+# Typing
+from typing import Any
+
+
+class IsInAdministratorsGroup(permissions.BasePermission):
+    """Permissions for the a user in the Administrators group."""
+
+    def has_permission(  # type: ignore
+        self,
+        request: request.Request,
+        view: viewsets.GenericViewSet,
+    ) -> bool:
+        """Checks viewset request level permissions.
+
+        Args:
+            request (request.Request): Request to check permissions.
+            view (viewsets.GenericViewSet): Viewset to check permissions.
+
+        Returns:
+            bool: Whether permission is allowed.
+        """
+        # Return
+        return utils.is_administrator(request.user)
+
+    def has_object_permission(  # type: ignore
+        self,
+        request: request.Request,
+        view: viewsets.GenericViewSet,
+        obj: Any,
+    ) -> bool:
+        """Checks object level permissions.
+
+        Args:
+            request (request.Request): Request to check permissions.
+            view (viewsets.GenericViewSet): Viewset to check permissions.
+            obj (Any): Object to check permissions.
+
+        Returns:
+            bool: Whether permission is allowed.
+        """
+        # Return
+        return utils.is_administrator(request.user)

--- a/govapp/apps/accounts/utils.py
+++ b/govapp/apps/accounts/utils.py
@@ -7,7 +7,7 @@ from django.contrib import auth
 from django.contrib.auth import models
 
 # Typing
-from typing import Iterable
+from typing import Iterable, Union
 
 
 # Shortcuts
@@ -35,4 +35,36 @@ def all_catalogue_editors() -> Iterable[models.User]:
     # Retrieve and Yield
     yield from UserModel.objects.filter(
         groups__id=conf.settings.GROUP_CATALOGUE_EDITOR_ID
+    )
+
+
+def is_administrator(user: Union[models.User, models.AnonymousUser]) -> bool:
+    """Checks whether a user is an Administrator.
+
+    Args:
+        user (Union[models.User, models.AnonymousUser]): User to be checked.
+
+    Returns:
+        bool: Whether the user is in the Administrator group.
+    """
+    # Check and Return
+    return (
+        not isinstance(user, models.AnonymousUser)  # Must be logged in
+        and user.groups.filter(id=conf.settings.GROUP_ADMINISTRATOR_ID).exists()  # Must be in group
+    )
+
+
+def is_catalogue_editor(user: Union[models.User, models.AnonymousUser]) -> bool:
+    """Checks whether a user is a Catalogue Editor.
+
+    Args:
+        user (Union[models.User, models.AnonymousUser]): User to be checked.
+
+    Returns:
+        bool: Whether the user is in the Catalogue Editor group.
+    """
+    # Check and Return
+    return (
+        not isinstance(user, models.AnonymousUser)  # Must be logged in
+        and user.groups.filter(id=conf.settings.GROUP_CATALOGUE_EDITOR_ID).exists()  # Must be in group
     )

--- a/govapp/apps/catalogue/serializers/catalogue_entries.py
+++ b/govapp/apps/catalogue/serializers/catalogue_entries.py
@@ -38,6 +38,7 @@ class CatalogueEntrySerializer(serializers.ModelSerializer):
             "status",
             "updated_at",
             "editors",
+            "assigned_to",
             "subscription",
             "active_layer",
             "layers",

--- a/govapp/commands.py
+++ b/govapp/commands.py
@@ -8,13 +8,14 @@ import logging
 from django.core import management
 from drf_spectacular import utils as drf_utils
 from rest_framework import decorators
-from rest_framework import permissions
 from rest_framework import request
 from rest_framework import response
 from rest_framework import routers
 from rest_framework import status
 from rest_framework import viewsets
 
+# Local
+from .apps.accounts import permissions
 
 # Logging
 log = logging.getLogger(__name__)
@@ -23,7 +24,7 @@ log = logging.getLogger(__name__)
 @drf_utils.extend_schema(tags=["Management Commands"])
 class ManagementCommands(viewsets.ViewSet):
     """Management Commands View Set."""
-    permission_classes = [permissions.IsAdminUser]
+    permission_classes = [permissions.IsInAdministratorsGroup]
 
     @drf_utils.extend_schema(request=None, responses={status.HTTP_204_NO_CONTENT: None})
     @decorators.action(detail=False, methods=["POST"], url_path=r"absorb/(?P<file>[^/]+)")

--- a/tests/test_apps/test_catalogue/test_permissions_flow.py
+++ b/tests/test_apps/test_catalogue/test_permissions_flow.py
@@ -383,3 +383,157 @@ def test_flow_catalogue_editor_and_assigned(
     assert client.post(
         path=f"/api/catalogue/entries/{entry.id}/lock/"
     ).status_code == status.HTTP_204_NO_CONTENT
+
+
+@pytest.mark.django_db()
+def test_flow_administrator(
+    client: test.Client,
+    catalogue_entry_factory: factories.catalogue.catalogue_entries.CatalogueEntryFactory,
+) -> None:
+    """Tests that the endpoints work correctly when an administrator.
+
+    Args:
+        client (test.Client): Django test client fixture.
+        catalogue_entry_factory (CatalogueEntryFactory): PyTest fixture for a
+            Catalogue Entry factory.
+    """
+    # Create Catalogue Entry
+    entry = catalogue_entry_factory.create()
+    assert isinstance(entry, models.catalogue_entries.CatalogueEntry)
+
+    # Create an Administrator User
+    # Use the user that was assigned to this Catalogue Entry, but remove it
+    # from the Catalogue Editors group, the Catalogue Entry's editors and
+    # unassign it
+    user = entry.assigned_to
+    assert isinstance(user, auth_models.User)
+    user.groups.add(conf.settings.GROUP_ADMINISTRATOR_ID)
+    user.groups.remove(conf.settings.GROUP_CATALOGUE_EDITOR_ID)
+    entry.editors.remove(user)
+    entry.assigned_to = None
+    entry.save()
+
+    # Authenticate
+    client.force_login(user)
+
+    # Render to JSON
+    entry_json = serializers.catalogue_entries.CatalogueEntrySerializer(entry)
+    entry_update_args: dict[str, Any] = {"data": entry_json.data, "content_type": "application/json"}
+
+    # Nobody can create a catalogue entry
+    assert client.post(
+        path="/api/catalogue/entries/",
+        **entry_update_args,
+    ).status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+
+    # Anyone can retrieve the catalogue entries and statuses
+    assert client.get(
+        path="/api/catalogue/entries/"
+    ).status_code == status.HTTP_200_OK
+    assert client.get(
+        path=f"/api/catalogue/entries/{entry.id}/"
+    ).status_code == status.HTTP_200_OK
+    assert client.get(
+        path="/api/catalogue/entries/status/"
+    ).status_code == status.HTTP_200_OK
+    assert client.get(
+        path=f"/api/catalogue/entries/status/{entry.status}/"
+    ).status_code == status.HTTP_200_OK
+
+    # Administrators can unlock the catalogue entry
+    assert client.post(
+        path=f"/api/catalogue/entries/{entry.id}/unlock/"
+    ).status_code == status.HTTP_204_NO_CONTENT
+
+    # Administrators can update the unlocked catalogue entry
+    assert client.put(
+        path=f"/api/catalogue/entries/{entry.id}/",
+        **entry_update_args,
+    ).status_code == status.HTTP_200_OK
+    assert client.patch(
+        path=f"/api/catalogue/entries/{entry.id}/",
+        **entry_update_args,
+    ).status_code == status.HTTP_200_OK
+
+    # Administrators can lock the catalogue entry
+    assert client.post(
+        path=f"/api/catalogue/entries/{entry.id}/lock/"
+    ).status_code == status.HTTP_204_NO_CONTENT
+
+    # Administrators cannot update the locked catalogue entry
+    assert client.put(
+        path=f"/api/catalogue/entries/{entry.id}/",
+        **entry_update_args,
+    ).status_code == status.HTTP_200_OK
+    assert client.patch(
+        path=f"/api/catalogue/entries/{entry.id}/",
+        **entry_update_args,
+    ).status_code == status.HTTP_200_OK
+
+    # Get a Layer Attribute
+    attr = entry.attributes.last()
+    assert isinstance(attr, models.layer_attributes.LayerAttribute)
+
+    # Render to JSON
+    attr_json = serializers.layer_attributes.LayerAttributeSerializer(attr)
+    attr_update_args: dict[str, Any] = {"data": attr_json.data, "content_type": "application/json"}
+
+    # Anyone can retrieve the layer attributes
+    assert client.get(
+        path="/api/catalogue/layers/attributes/"
+    ).status_code == status.HTTP_200_OK
+    assert client.get(
+        path=f"/api/catalogue/layers/attributes/{attr.id}/"
+    ).status_code == status.HTTP_200_OK
+
+    # Administrators can update the attributes if the catalogue entry is locked
+    assert client.put(
+        path=f"/api/catalogue/layers/attributes/{attr.id}/",
+        **attr_update_args
+    ).status_code == status.HTTP_200_OK
+    assert client.patch(
+        path=f"/api/catalogue/layers/attributes/{attr.id}/",
+        **attr_update_args
+    ).status_code == status.HTTP_200_OK
+
+    # Administrators can delete the attributes if the catalogue entry is locked
+    assert client.delete(
+        path=f"/api/catalogue/layers/attributes/{attr.id}/"
+    ).status_code == status.HTTP_204_NO_CONTENT
+
+    # Administrators can create new attributes if the catalogue entry is locked
+    assert client.post(
+        path="/api/catalogue/layers/attributes/",
+        **attr_update_args
+    ).status_code == status.HTTP_201_CREATED
+
+    # Administrators can unlock the catalogue entry
+    assert client.post(
+        path=f"/api/catalogue/entries/{entry.id}/unlock/"
+    ).status_code == status.HTTP_204_NO_CONTENT
+
+    # Administrators can update the attributes if the catalogue entry is unlocked
+    assert client.put(
+        path=f"/api/catalogue/layers/attributes/{attr.id + 1}/",
+        **attr_update_args
+    ).status_code == status.HTTP_200_OK
+    assert client.patch(
+        path=f"/api/catalogue/layers/attributes/{attr.id + 1}/",
+        **attr_update_args
+    ).status_code == status.HTTP_200_OK
+
+    # Administrators can delete the attributes if the catalogue entry is unlocked
+    assert client.delete(
+        path=f"/api/catalogue/layers/attributes/{attr.id + 1}/"
+    ).status_code == status.HTTP_204_NO_CONTENT
+
+    # Administrators can create new attributes if the catalogue entry is unlocked
+    assert client.post(
+        path="/api/catalogue/layers/attributes/",
+        **attr_update_args
+    ).status_code == status.HTTP_201_CREATED
+
+    # Administrators can lock the catalogue entry
+    assert client.post(
+        path=f"/api/catalogue/entries/{entry.id}/lock/"
+    ).status_code == status.HTTP_204_NO_CONTENT


### PR DESCRIPTION
## Summary
* Adds `POST /catalogue/entry/x/assign/y` endpoint and permissions
* Adds `POST /catalogue/entry/x/unassign` endpoint and permissions
* Refactor permissions utilities slightly
* Make `assigned_to` read-only in `PUT`/`PATCH` requests