### PR TITLE
Scanner cron job

### DIFF
--- a/cron
+++ b/cron
@@ -1,1 +1,3 @@
 # Add crons below
+# Copied from https://github.com/dbca-wa/boranga/blob/main/cron
+*/5 * * * * root eval $(grep -v '^#' /etc/.cronenv | xargs -d "\n" -I {} echo export \"{}\" ) && python3 /app/manage.py runcrons >> /app/logs/cronjob.log 2>&1

--- a/govapp/apps/catalogue/cron.py
+++ b/govapp/apps/catalogue/cron.py
@@ -1,0 +1,28 @@
+"""Kaartdijin Boodja Catalogue Django Application Cron Jobs."""
+
+
+# Standard
+import logging
+
+# Third-Party
+from django import conf
+from django.core import management
+import django_cron
+
+
+# Logging
+log = logging.getLogger(__name__)
+
+
+class ScannerCronJob(django_cron.CronJobBase):
+    """Cron Job for the Catalogue Scanner."""
+    schedule = django_cron.Schedule(run_every_mins=conf.settings.CRON_SCANNER_PERIOD_MINS)
+    code = "govapp.catalogue.scanner"
+
+    def do(self) -> None:
+        """Perform the Scanner Cron Job."""
+        # Log
+        log.info("Scanner cron job triggered, running...")
+
+        # Run Management Command
+        management.call_command("scan")

--- a/govapp/commands.py
+++ b/govapp/commands.py
@@ -5,6 +5,7 @@
 import logging
 
 # Third-Party
+from django import conf
 from django.core import management
 from drf_spectacular import utils as drf_utils
 from rest_framework import decorators
@@ -26,29 +27,6 @@ class ManagementCommands(viewsets.ViewSet):
     permission_classes = [permissions.IsAdminUser]
 
     @drf_utils.extend_schema(request=None, responses={status.HTTP_204_NO_CONTENT: None})
-    @decorators.action(detail=False, methods=["POST"], url_path=r"absorb/(?P<file>[^/]+)")
-    def absorb(self, request: request.Request, file: str) -> response.Response:
-        """Runs the `absorb` Management Command.
-
-        Args:
-            request (request.Request): API request.
-
-        Returns:
-            response.Response: Empty response confirming success.
-        """
-        # Handle Errors
-        try:
-            # Run Management Command
-            management.call_command("absorb", file)
-
-        except Exception as exc:
-            # Log
-            log.error(f"Unable to perform absorb on '{file}': {exc}")
-
-        # Return Response
-        return response.Response(status=status.HTTP_204_NO_CONTENT)
-
-    @drf_utils.extend_schema(request=None, responses={status.HTTP_204_NO_CONTENT: None})
     @decorators.action(detail=False, methods=["POST"])
     def scan(self, request: request.Request) -> response.Response:
         """Runs the `scan` Management Command.
@@ -62,7 +40,13 @@ class ManagementCommands(viewsets.ViewSet):
         # Handle Errors
         try:
             # Run Management Command
-            management.call_command("scan")
+            # Here, instead of directly running the `scan` management command
+            # we run it via the `runcrons` command. This allows us to take
+            # advantage of the builtin locking functionality - i.e., we won't
+            # be able to run the scanner if its already running. The `--force`
+            # option is used to allow us to call the scanner whenever we want,
+            # but it does not bypass the concurrency locking.
+            management.call_command("runcrons", conf.settings.CRON_SCANNER_CLASS, "--force")
 
         except Exception as exc:
             # Log

--- a/govapp/settings.py
+++ b/govapp/settings.py
@@ -205,10 +205,11 @@ GROUP_CATALOGUE_EDITOR_NAME = "Catalogue Editors"
 # Cron Jobs
 # https://django-cron.readthedocs.io/en/latest/installation.html
 # https://django-cron.readthedocs.io/en/latest/configuration.html
-CRON_CLASSES = [
-    "govapp.apps.catalogue.cron.ScannerCronJob",
-]
+CRON_SCANNER_CLASS = "govapp.apps.catalogue.cron.ScannerCronJob"
 CRON_SCANNER_PERIOD_MINS = 5  # Run every 5 minutes
+CRON_CLASSES = [
+    CRON_SCANNER_CLASS,
+]
 
 # Temporary Fix for ARM Architecture
 if platform.machine() == "arm64":

--- a/govapp/settings.py
+++ b/govapp/settings.py
@@ -203,6 +203,8 @@ GROUP_CATALOGUE_EDITOR_ID = 2
 GROUP_CATALOGUE_EDITOR_NAME = "Catalogue Editors"
 
 # Cron Jobs
+# https://django-cron.readthedocs.io/en/latest/installation.html
+# https://django-cron.readthedocs.io/en/latest/configuration.html
 CRON_CLASSES = [
     "govapp.apps.catalogue.cron.ScannerCronJob",
 ]

--- a/govapp/settings.py
+++ b/govapp/settings.py
@@ -57,6 +57,7 @@ INSTALLED_APPS = [
     "drf_spectacular",
     "django_filters",
     "reversion",
+    "django_cron",
 ]
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
@@ -200,6 +201,12 @@ GROUP_ADMINISTRATOR_ID = 1
 GROUP_ADMINISTRATOR_NAME = "Administrators"
 GROUP_CATALOGUE_EDITOR_ID = 2
 GROUP_CATALOGUE_EDITOR_NAME = "Catalogue Editors"
+
+# Cron Jobs
+CRON_CLASSES = [
+    "govapp.apps.catalogue.cron.ScannerCronJob",
+]
+CRON_SCANNER_PERIOD_MINS = 5  # Run every 5 minutes
 
 # Temporary Fix for ARM Architecture
 if platform.machine() == "arm64":

--- a/poetry.lock
+++ b/poetry.lock
@@ -186,17 +186,6 @@ argon2 = ["argon2-cffi (>=19.1.0)"]
 bcrypt = ["bcrypt"]
 
 [[package]]
-name = "django-common-helpers"
-version = "0.9.2"
-description = "Common things every Django app needs!"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-Django = ">=1.8.0"
-
-[[package]]
 name = "django-confy"
 version = "1.0.4"
 description = "Django project configuration helpers"
@@ -240,15 +229,14 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "django-cron"
-version = "0.5.0"
+version = "0.6.0"
 description = "Running python crons in a Django project"
 category = "main"
 optional = false
 python-versions = "*"
 
 [package.dependencies]
-Django = ">=1.8.0"
-django-common-helpers = ">=0.6.4"
+Django = ">=3.2"
 
 [[package]]
 name = "django-filter"
@@ -1273,7 +1261,7 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "0cfd049892369e90b0374da95cb8b2bc56d4fd87e1a2846e06a6976b2e32d73e"
+content-hash = "c6122cdb0dc59f2c92c9171af203c5408aae7c07d4be1ebd06fd98b7972e1824"
 
 [metadata.files]
 asgiref = [
@@ -1463,9 +1451,6 @@ django = [
     {file = "Django-3.2.16-py3-none-any.whl", hash = "sha256:18ba8efa36b69cfcd4b670d0fa187c6fe7506596f0ababe580e16909bcdec121"},
     {file = "Django-3.2.16.tar.gz", hash = "sha256:3adc285124244724a394fa9b9839cc8cd116faf7d159554c43ecdaa8cdf0b94d"},
 ]
-django-common-helpers = [
-    {file = "django-common-helpers-0.9.2.tar.gz", hash = "sha256:2d56be6fa261d829a6a224f189bf276267b9082a17d613fe5f015dd4d65c17b4"},
-]
 django-confy = [
     {file = "django-confy-1.0.4.tar.gz", hash = "sha256:35b0242a54d484dac05c1a59d6d9d0a5bb4241651c365ad23b60e5a46ff7b3b1"},
     {file = "django_confy-1.0.4-py3-none-any.whl", hash = "sha256:cde50fd3d087d850a7aa59e053ba2f0d5b3866c5ec82a96e3035ac4ded4c3b38"},
@@ -1483,7 +1468,8 @@ django-crispy-forms = [
     {file = "django_crispy_forms-1.14.0-py3-none-any.whl", hash = "sha256:bc4d2037f6de602d39c0bc452ac3029d1f5d65e88458872cc4dbc01c3a400604"},
 ]
 django-cron = [
-    {file = "django-cron-0.5.0.tar.gz", hash = "sha256:bc56511e3250e4f47fc37d40beb1680c7ecadb3689e4139eee78677e24a60edf"},
+    {file = "django-cron-0.6.0.tar.gz", hash = "sha256:dc3c0d3433a2e4e7012f77f6d8415ad90367ba068649db2674325bc36f935841"},
+    {file = "django_cron-0.6.0-py3-none-any.whl", hash = "sha256:016203554748512b7f19d7363b4fde8741c6ff63fe8a15051f3031f4a0506a41"},
 ]
 django-filter = [
     {file = "django-filter-22.1.tar.gz", hash = "sha256:ed473b76e84f7e83b2511bb2050c3efb36d135207d0128dfe3ae4b36e3594ba5"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,10 +19,10 @@ python-dateutil = "^2.8.2"
 shareplum = "^0.5.1"
 django-reversion = "^5.0.4"
 django-reversion-rest-framework = "^1.1.2"
+django-cron = "^0.6.0"
 # DBCA Template Dependencies
 django-confy = "1.0.4"
 whitenoise = "5.3.0"
-django-cron = "0.5.0"
 django_media_serv = {git = "https://github.com/dbca-wa/django-media-serv.git" }
 gunicorn = "19.9.0"
 gevent = "21.12.0"


### PR DESCRIPTION
## Summary
* Utilises `django-cron` to create a "scanner" cron job which runs every `5` minutes (configurable)
    * Updates `django-cron` dependency to latest version
    * Adds entry to `cron` file (copied from Boranga project) for `django-cron`
    * Adds `apps.catalogue.cron` module containing `ScannerCronJob` to run the scanner
    * Adds `django-cron` settings in `settings.py` (i.e., run frequency)
    * Change `/commands/scan` to use `runcrons` for free concurrency locking
    * Remove `/commands/absorb/x` (useless)

## Locking
* We must lock the cron-job, so subsequent calls don't overlap or interfere with each other
* `django-cron` actually has this locking functionality inbuilt and enabled by default
* See: https://django-cron.readthedocs.io/en/latest/locking_backend.html
* I have tested this functionality and it appears to work: ![locking](https://user-images.githubusercontent.com/99162803/207486010-25823854-4e3c-41af-9311-7691728cc6b5.png)