### PR TITLE
Email administrators upon file absorb failure (e.g., bad filetype)

### DIFF
--- a/govapp/apps/catalogue/emails.py
+++ b/govapp/apps/catalogue/emails.py
@@ -25,3 +25,10 @@ class CatalogueEntryUpdateFailEmail(emails.TemplateEmailBase):
     subject = "A Catalogue Entry update failed"
     html_template = "catalogue_entry_update_fail_email.html"
     txt_template = "catalogue_entry_update_fail_email.txt"
+
+
+class FileAbsorbFailEmail(emails.TemplateEmailBase):
+    """File Absorb Fail Email Abstraction."""
+    subject = "A file absorption failed"
+    html_template = "file_absorb_fail_email.html"
+    txt_template = "file_absorb_fail_email.txt"

--- a/govapp/apps/catalogue/scanner.py
+++ b/govapp/apps/catalogue/scanner.py
@@ -9,7 +9,9 @@ from django import conf
 
 # Local
 from . import absorber
+from . import emails
 from . import storage
+from ..accounts import utils
 
 
 # Logging
@@ -56,6 +58,11 @@ class Scanner:
             except Exception as exc:
                 # Log and continue
                 log.error(f"Error absorbing file '{file}': {exc}")
+
+                # Send Emails!
+                emails.FileAbsorbFailEmail().send_to_users(
+                    *utils.all_administrators(),  # Send to all administrators
+                )
 
         # Log
         log.info("Scanning storage staging area complete!")

--- a/govapp/apps/catalogue/templates/file_absorb_fail_email.html
+++ b/govapp/apps/catalogue/templates/file_absorb_fail_email.html
@@ -1,0 +1,7 @@
+{% extends 'base_email.html' %}
+
+{% block content %}
+<p>
+    A file failed to absorb!
+</p>
+{% endblock %}

--- a/govapp/apps/catalogue/templates/file_absorb_fail_email.txt
+++ b/govapp/apps/catalogue/templates/file_absorb_fail_email.txt
@@ -1,0 +1,5 @@
+{% extends 'base_email.txt' %}
+
+{% block content %}
+A file failed to absorb!
+{% endblock %}


### PR DESCRIPTION
## Summary
* Adds new email template (skeleton) `file_absorb_fail_email.{html,txt}`
* Adds new email template abstraction `FileAbsorbFailEmail`
* Adds functionality to email all administrators upon file absorb failure (any reason)