### PR TITLE
Add `docker-compose` file for running GeoServer locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules/
 .mypy_cache/
 .pytest_cache/
 cache/
+data/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.9"
+services:
+  geoserver:
+    image: "kartoza/geoserver:latest"
+    ports:
+      - "8600:8080"
+    environment:
+      GEOSERVER_ADMIN_USER: admin
+      GEOSERVER_ADMIN_PASSWORD: geoserver
+      GEOSERVER_DATA_DIR: /data
+      STABLE_EXTENSIONS: authkey-plugin sldservice-plugin wps-plugin querylayer-plugin mbstyle-plugin css-plugin mongodb-plugin
+      COMMUNITY_EXTENSIONS: geopkg-plugin
+    volumes:
+      - ./data:/data


### PR DESCRIPTION
## Summary
* As per title, adds `docker-compose.yml` for running GeoServer locally
* GeoServer data directory is bind-mounted to the (`.gitignore`'d) local `./data` directory
* Usage: `docker-compose up` - starts GeoServer at `http://localhost:8600/geoserver`