### PR TITLE
chore: use /app/tmp as base directory for GIS conversion temp files

### DIFF
--- a/govapp/gis/compression.py
+++ b/govapp/gis/compression.py
@@ -11,6 +11,7 @@ import datetime
 import os
 
 # Third-Party
+import decouple
 import py7zr
 import pytz
 import rarfile
@@ -70,13 +71,14 @@ def decompress(file: pathlib.Path) -> pathlib.Path:
         return file  # Return the original filepath
     log.info(f"Detected compression: [{algorithm}]")
 
-    pathlib.Path('/app/tmp/gis_processing/').mkdir(parents=True, exist_ok=True)
+    _gis_tmp = pathlib.Path(decouple.config("GIS_TMP_DIR", default="/app/tmp")) / "gis_processing"
+    _gis_tmp.mkdir(parents=True, exist_ok=True)
 
     log.info(f"Preparing decompressing the file: [{file}]...")
     timestamp_str = datetime.datetime.now(pytz.utc).strftime("%Y%m%dT%H%M%S")
 
     # Construct Path for Extraction
-    extracted_path = pathlib.Path("/app/tmp/gis_processing/extracted_" + file.stem + "_" + timestamp_str)
+    extracted_path = _gis_tmp / ("extracted_" + file.stem + "_" + timestamp_str)
     log.info(f"Decompressing the file:[{file}] to the folder: [{extracted_path}]...")
 
     # Decompress

--- a/govapp/gis/compression.py
+++ b/govapp/gis/compression.py
@@ -70,14 +70,13 @@ def decompress(file: pathlib.Path) -> pathlib.Path:
         return file  # Return the original filepath
     log.info(f"Detected compression: [{algorithm}]")
 
-    if not os.path.exists('/tmp/gis_processing/'):
-        os.makedirs('/tmp/gis_processing/')
+    pathlib.Path('/app/tmp/gis_processing/').mkdir(parents=True, exist_ok=True)
 
     log.info(f"Preparing decompressing the file: [{file}]...")
     timestamp_str = datetime.datetime.now(pytz.utc).strftime("%Y%m%dT%H%M%S")
 
     # Construct Path for Extraction
-    extracted_path = pathlib.Path("/tmp/gis_processing/extracted_" + file.stem + "_" + timestamp_str)
+    extracted_path = pathlib.Path("/app/tmp/gis_processing/extracted_" + file.stem + "_" + timestamp_str)
     log.info(f"Decompressing the file:[{file}] to the folder: [{extracted_path}]...")
 
     # Decompress

--- a/govapp/gis/conversions.py
+++ b/govapp/gis/conversions.py
@@ -12,6 +12,10 @@ from osgeo import gdal
 from govapp.gis import compression
 
 
+# Temporary directory base for all conversions
+_TMP_BASE = pathlib.Path("/app/tmp")
+_TMP_BASE.mkdir(parents=True, exist_ok=True)
+
 # Logging
 log = logging.getLogger(__name__)
 
@@ -34,7 +38,7 @@ def to_geopackage(filepath: pathlib.Path, layer: str, catalogue_name: str, expor
         filepath = compression.flatten(filepath)
 
         # Construct Output Filepath
-        output_dir = tempfile.mkdtemp()
+        output_dir = tempfile.mkdtemp(dir=_TMP_BASE)
         output_filepath = pathlib.Path(output_dir) / f"{layer}.gpkg"
 
         # --- START: NEW LOGIC TO DETECT RASTER/VECTOR ---
@@ -139,7 +143,7 @@ def to_geojson(filepath: pathlib.Path, layer: str, catalogue_name: str = '', exp
         filepath = compression.flatten(filepath)
 
         # Construct Output Filepath
-        output_dir = tempfile.mkdtemp()
+        output_dir = tempfile.mkdtemp(dir=_TMP_BASE)
         output_filepath = pathlib.Path(output_dir) / f"{layer}.geojson"
 
         command = [
@@ -196,7 +200,7 @@ def to_shapefile(filepath: pathlib.Path, layer: str, catalogue_name: str, export
 
         # Construct Output Filepath
         # Here we double up on the `layer.shp` to ensure its in a directory
-        output_dir = tempfile.mkdtemp()
+        output_dir = tempfile.mkdtemp(dir=_TMP_BASE)
         output_filepath = pathlib.Path(output_dir) / f"{layer}.shp"
         output_filepath.mkdir(parents=True, exist_ok=True)
         output_filepath = output_filepath / f"{layer}.shp"
@@ -256,7 +260,7 @@ def to_geodatabase(filepath: pathlib.Path, layer: str, catalogue_name: str, expo
 
         # Construct Output Filepath
         # Here we double up on the `layer.gdb` to ensure its in a directory
-        output_dir = tempfile.mkdtemp()
+        output_dir = tempfile.mkdtemp(dir=_TMP_BASE)
         output_filepath = pathlib.Path(output_dir) / f"{layer}.gdb"
         output_filepath.mkdir(parents=True, exist_ok=True)
         output_filepath = output_filepath / f"{layer}.gdb"
@@ -305,7 +309,7 @@ def postgres_to_shapefile(layer_name: str, hostname: str, username: str, passwor
 
     try:
         converted = {}
-        output_dir = tempfile.mkdtemp()
+        output_dir = tempfile.mkdtemp(dir=_TMP_BASE)
         cleaned_sqlquery = sqlquery.replace('\n', ' ')
 
         command = [

--- a/govapp/gis/conversions.py
+++ b/govapp/gis/conversions.py
@@ -8,12 +8,15 @@ import subprocess  # noqa: S404
 import tempfile
 from osgeo import gdal
 
+# Third-Party
+import decouple
+
 # Local
 from govapp.gis import compression
 
 
 # Temporary directory base for all conversions
-_TMP_BASE = pathlib.Path("/app/tmp")
+_TMP_BASE = pathlib.Path(decouple.config("GIS_TMP_DIR", default="/app/tmp"))
 _TMP_BASE.mkdir(parents=True, exist_ok=True)
 
 # Logging


### PR DESCRIPTION
Replace default system temp dir (/tmp) with /app/tmp for all tempfile.mkdtemp() calls in conversions.py. The base directory is created automatically on module import if it does not exist.