### PR TITLE
chore(docker): purge linux-libc-dev package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -114,6 +114,7 @@ USER root
 RUN wget https://raw.githubusercontent.com/dbca-wa/wagov_utils/refs/heads/main/wagov_utils/bin/package_cleanup_2604.sh -O /tmp/package_cleanup_2604.sh
 RUN chmod 755 /tmp/package_cleanup_2604.sh
 RUN /tmp/package_cleanup_2604.sh
+RUN apt purge -y linux-libc-dev
 USER oim
 
 EXPOSE 8080


### PR DESCRIPTION
Remove unneeded linux-libc-dev package from container image.